### PR TITLE
Work from IOC capabilities development project branch

### DIFF
--- a/.github/workflows/project-pull-request.yml
+++ b/.github/workflows/project-pull-request.yml
@@ -4,8 +4,8 @@ run-name: Pull request for ${{ github.head_ref }} to ${{ github.base_ref }} by $
 
 env:
   LINT_FLAGS: -W clippy::all -W clippy::pedantic -W clippy::cargo
-  RUST_TOOLCHAIN: 'nightly-2024-07-21'
-  LLVM_VERSION: 18
+  RUST_TOOLCHAIN: 'nightly-2024-11-28'
+  LLVM_VERSION: 19
 
 on:
   pull_request:

--- a/.github/workflows/project-push.yml
+++ b/.github/workflows/project-push.yml
@@ -4,8 +4,8 @@ run-name: Push to ${{ github.ref_name }} by ${{ github.actor }}
 
 env:
   LINT_FLAGS: -W clippy::all -W clippy::pedantic -W clippy::cargo
-  RUST_TOOLCHAIN: 'nightly-2024-07-21'
-  LLVM_VERSION: 18
+  RUST_TOOLCHAIN: 'nightly-2024-11-28'
+  LLVM_VERSION: 19
 
 on:
   push:

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -23,8 +23,7 @@
 //! and decoding objects for transmission over the network, as opposed
 //! to the [serde] framework.  This is done for several reasons:
 //!
-//! * It allows the exact formats of messages to vary for different
-//!   channels.
+//! * It allows the exact formats of messages to vary for different channels.
 //!
 //! * It allows more precise control over the exact message formats.
 //!

--- a/src/codec/per.rs
+++ b/src/codec/per.rs
@@ -129,7 +129,6 @@ where
         Ok(writer.into_bytes_vec())
     }
 
-    #[inline]
     fn decode(
         &mut self,
         buf: &[u8]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,8 @@
 
 #[allow(clippy::all)]
 #[rustfmt::skip]
-// mod generated;
+
+mod generated;
 
 pub mod codec;
 pub mod config;
@@ -49,7 +50,7 @@ pub mod retry;
 pub mod sched;
 pub mod shutdown;
 pub mod sync;
-// pub mod version;
+pub mod version;
 
 #[cfg(test)]
 use std::sync::Once;

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -136,7 +136,7 @@ pub struct Retry {
 }
 
 /// A return type for non-blocking functions that can indicate a delay.
-#[derive(Clone)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum RetryResult<T, R: RetryWhen = Instant> {
     /// An immediate result.
     Success(T),


### PR DESCRIPTION
Several changes from pre-IOC capabilities development project, including:
- Addition of `IoVec` functions to socket API
- Types for representing versions

Addresses #6.